### PR TITLE
return null for number and percentage if input is empty

### DIFF
--- a/src/global/number/number.js
+++ b/src/global/number/number.js
@@ -22,7 +22,7 @@ function NumberMaskDirective($locale, $parse, PreFormatters, NumberMasks) {
 
 			function parser(value) {
 				if(ctrl.$isEmpty(value)) {
-					return value;
+					return null;
 				}
 
 				var valueToFormat = PreFormatters.clearDelimitersAndLeadingZeros(value) || '0';

--- a/src/global/number/number.test.js
+++ b/src/global/number/number.test.js
@@ -49,6 +49,20 @@ describe('ui-number-mask', function() {
 		expect(model.$viewValue).toBe('3456.79');
 	});
 
+	it('should return null if field is empty', function () {
+		var input = TestUtil.compile('<input ng-model="model" ui-number-mask>', {
+			model: 1000
+		});
+
+		var model = input.controller('ngModel');
+		input.val('').triggerHandler('input');
+
+		expect(model.$viewValue).toBe('');
+		expect(model.$modelValue).toBeNull();
+		expect(model.$valid).toBe(true);
+
+	});
+
 	it('should validate minimum value', function() {
 		var input = TestUtil.compile('<input ng-model="model" ui-number-mask min="50">', {
 			model: '3456.79'
@@ -101,7 +115,7 @@ describe('ui-number-mask', function() {
 			{modelValue: '', viewValue: ''},
 			{modelValue: '0', viewValue: '0.00'},
 			{modelValue: '0.0', viewValue: '0.00'},
-			{modelValue: 0, viewValue: '0.00'},
+			{modelValue: 0, viewValue: '0.00'}
 		];
 
 		tests.forEach(function(test) {

--- a/src/global/percentage/percentage.js
+++ b/src/global/percentage/percentage.js
@@ -46,7 +46,7 @@ function PercentageMaskDirective($locale, $parse, PreFormatters, NumberMasks) {
 
 			function parse(value) {
 				if (ctrl.$isEmpty(value)) {
-					return value;
+					return null;
 				}
 
 				var valueToFormat = PreFormatters.clearDelimitersAndLeadingZeros(value) || '0';

--- a/src/global/percentage/percentage.test.js
+++ b/src/global/percentage/percentage.test.js
@@ -29,6 +29,20 @@ describe('ui-percentage-mask', function() {
 		expect(model.$viewValue).toBe('1,234.50 %');
 	});
 
+	it('should return null if field is empty', function () {
+		var input = TestUtil.compile('<input ng-model="model" ui-percentage-mask>', {
+			model: 12.3
+		});
+
+		var model = input.controller('ngModel');
+		input.val('').triggerHandler('input');
+
+		expect(model.$viewValue).toBe('');
+		expect(model.$modelValue).toBeNull();
+		expect(model.$valid).toBe(true);
+
+	});
+
 	it('should hide thousands delimiter when ui-hide-group-sep is present', function() {
 		var input = TestUtil.compile('<input ng-model="model" ui-percentage-mask ui-hide-group-sep>', {
 			model: '12.345'


### PR DESCRIPTION
To be compliant with the angular input[number], the ui-number-mask
and ui-percentage-mask should parse an empty value to null and not
to undefined (or an empty string). This has an advantage, that performing
calculations with null is possible (e.g. 5 + null === 5). If
undefined or a string would be returned, then the model
has an illegal value and an explicit check for undefined is required
in all calculations...
