### PR TITLE
Fix ui-number-mask="0" is undefined when model is 0

### DIFF
--- a/src/global/number/number.test.js
+++ b/src/global/number/number.test.js
@@ -111,6 +111,16 @@ describe('ui-number-mask', function() {
 		});
 	}));
 
+	it('should show zero when the model value is zero and the precision is set to 0', inject(function($rootScope) {
+		var input = TestUtil.compile('<input ng-model="model" ui-number-mask="0">');
+		var model = input.controller('ngModel');
+
+
+		$rootScope.model = 0;
+		$rootScope.$digest();
+		expect(model.$viewValue).toBe('0');
+	}));
+
 	it('should accept negative numbers if "ui-negative-number" is defined', function() {
 		var input = TestUtil.compile('<input ng-model="model" ui-number-mask ui-negative-number>');
 		var model = input.controller('ngModel');

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -6,9 +6,12 @@ module.exports = m.name;
 
 m.factory('PreFormatters', [function(){
 	function clearDelimitersAndLeadingZeros(value) {
+		if (value === '0') {
+			return '0';
+		}
+
 		var cleanValue = value.replace(/^-/,'').replace(/^0*/, '');
-		cleanValue = cleanValue.replace(/[^0-9]/g, '');
-		return cleanValue;
+		return cleanValue.replace(/[^0-9]/g, '');
 	}
 
 	function prepareNumberToFormatter (value, decimals) {


### PR DESCRIPTION
When ui-number-mask="0" is used and the model changes the value to 0,
then undefined is displayed in the input field. The cause of the error
is, that clearDelimitersAndLeadingZero does not only clear leading
zeros, but also a single 0 (what is equal to the vaue 0).

-> Do not strip a single 0.

Fixes ##111
